### PR TITLE
Edits required to fully port decorrelation length overlap scheme

### DIFF
--- a/GFS_layer/GFS_radiation_driver.F90
+++ b/GFS_layer/GFS_radiation_driver.F90
@@ -1213,9 +1213,10 @@
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP) :: &
            htswc, htlwc, gcice, grain, grime, htsw0, htlw0, plyr, tlyr,    &
            qlyr, olyr, rhly, tvly,qstl, vvel, clw, ciw, prslk1, tem2da,    &
-           dz,delp,tem2db, cldcov, deltaq, cnvc, cnvw, qa, tau067, tau110
+           dz,delp, cldcov, deltaq, cnvc, cnvw, qa, tau067, tau110
 
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+1+LTP) :: plvl, tlvl
+      real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+ltp+1) :: tem2db
 
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP,2:Model%ntrac) :: tracer1
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP,NF_CLDS) :: clouds
@@ -1401,7 +1402,7 @@
             qlyr(i,k1) = max( tem1d(i), Statein%qgrs(i,k,1) )
             tem1d(i)   = min( QME5, qlyr(i,k1) )
             tvly(i,k1) = Statein%tgrs(i,k) * (1.0 + fvirt*qlyr(i,k1)) ! virtual T (K)
-            delp(i,lyb) = plvl(i,lla) - plvl(i,llb)
+            delp(i,k1) = plvl(i,k1+1) - plvl(i,k1)
           enddo
         enddo
 
@@ -1447,7 +1448,7 @@
             qlyr(i,k) = max( tem1d(i), Statein%qgrs(i,k,1) )
             tem1d(i)  = min( QME5, qlyr(i,k) )
             tvly(i,k) = Statein%tgrs(i,k) * (1.0 + fvirt*qlyr(i,k)) ! virtual T (K)
-            delp(i,lyb) = plvl(i,lla) - plvl(i,llb)
+            delp(i,k) = plvl(i,k) - plvl(i,k+1)
           enddo
         enddo
 

--- a/GFS_layer/GFS_radiation_driver.F90
+++ b/GFS_layer/GFS_radiation_driver.F90
@@ -1204,7 +1204,7 @@
       real(kind=kind_phys) :: raddt, es, qs, delt, tem0d 
 
       real(kind=kind_phys), dimension(size(Grid%xlon,1)) ::             &
-           tsfa, cvt1, cvb1, tem1d, tsfg, tskn
+           tsfa, cvt1, cvb1, tem1d, tsfg, tskn, de_lgth
 
       real(kind=kind_phys), dimension(size(Grid%xlon,1),5)       :: cldsa
       real(kind=kind_phys), dimension(size(Grid%xlon,1),NSPC1)   :: aerodp
@@ -1585,31 +1585,31 @@
           if (Model%uni_cld .and. Model%ncld >= 2) then
             call progclduni (plyr, plvl, tlyr, tvly, clw, ciw,    &    !  ---  inputs
                              Grid%xlat, Grid%xlon, Sfcprop%slmsk, &
-                             IM, LMK, LMP, cldcov(:,1:LMK),       &
-                             clouds, cldsa, mtopa, mbota)              !  ---  outputs
+                             dz, IM, LMK, LMP, cldcov(:,1:LMK),   &
+                             clouds, cldsa, mtopa, mbota, de_lgth)     !  ---  outputs
           else
             call progcld1 (plyr ,plvl, tlyr, tvly, qlyr, qstl,    &    !  ---  inputs
                            rhly, clw, Grid%xlat,Grid%xlon,        &
-                           Sfcprop%slmsk, IM, LMK, LMP,           &
+                           Sfcprop%slmsk, dz, IM, LMK, LMP,       &
                            Model%uni_cld, Model%lmfshal,          &
                            Model%lmfdeep2, cldcov(:,1:LMK),       &
-                           clouds, cldsa, mtopa, mbota)                !  ---  outputs
+                           clouds, cldsa, mtopa, mbota, de_lgth)       !  ---  outputs
           endif
 
         elseif(icmphys == 3) then      ! zhao/moorthi's prognostic cloud+pdfcld
 
           call progcld3 (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,&    !  ---  inputs
                          clw, cnvw, cnvc, Grid%xlat, Grid%xlon,   &
-                         Sfcprop%slmsk,im, lmk, lmp, deltaq,      &
+                         Sfcprop%slmsk,dz,im, lmk, lmp, deltaq,   &
                          Model%sup, Model%kdt, me,                &
-                         clouds, cldsa, mtopa, mbota)                  !  ---  outputs
+                         clouds, cldsa, mtopa, mbota, de_lgth)         !  ---  outputs
 
         elseif (icmphys == 4) then           ! zhao/moorthi's prognostic cloud scheme
 
           call progcld4 (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,&    !  ---  inputs
                          clw, Grid%xlat, Grid%xlon, Sfcprop%slmsk,&
-                         tracer1(:,1:lmk,Model%ntclamt), im, lmk, &
-                         lmp,                                     &
+                         tracer1(:,1:lmk,Model%ntclamt), dz, im,  &
+                         lmk, lmp,                                &
                          clouds, cldsa, mtopa, mbota, de_lgth)         !  ---  outputs
 
         elseif (icmphys == 5) then           ! zhao/moorthi's prognostic cloud scheme + pdf cloud & cnvc and cnvw
@@ -1618,7 +1618,8 @@
           call progcld5 (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,&    !  ---  inputs
                          clw, cnvw, cnvc, Grid%xlat, Grid%xlon,   &
                          Sfcprop%slmsk, tracer1(:,1:lmk,Model%ntclamt),&
-                         im, lmk, lmp, clouds, cldsa, mtopa, mbota)    !  ---  outputs
+                         dz, im, lmk, lmp,                        &
+                         clouds, cldsa, mtopa, mbota, de_lgth)         !  ---  outputs
           else
           if (Model%ntal .gt. 0) then
               qa(:,:) = tracer1(:,1:lmk,Model%ntal)
@@ -1631,10 +1632,11 @@
                          tracer1(:,1:lmk,Model%ntrw), &
                          tracer1(:,1:lmk,Model%ntiw), &
                          tracer1(:,1:lmk,Model%ntsw), &
-                         tracer1(:,1:lmk,Model%ntgl), qa, &
+                         tracer1(:,1:lmk,Model%ntgl), &
                          Sfcprop%slmsk, Sfcprop%snowd, &
-                         tracer1(:,1:lmk,Model%ntclamt),&
-                         im, lmk, lmp, clouds, cldsa, mtopa, mbota)    !  ---  outputs
+                         tracer1(:,1:lmk,Model%ntclamt), qa, dz, &
+                         im, lmk, lmp, &
+                         clouds, cldsa, mtopa, mbota, de_lgth)    !  ---  outputs
           endif
 
         endif                            ! end if_icmphys
@@ -1656,8 +1658,8 @@
 
         call diagcld1 (plyr, plvl, tlyr, rhly, vvel, Cldprop%cv,  &    !  ---  inputs
                        cvt1, cvb1, Grid%xlat, Grid%xlon,          &
-                       Sfcprop%slmsk, IM, LMK, LMP,               &
-                       clouds, cldsa, mtopa, mbota)                    !  ---  outputs
+                       Sfcprop%slmsk, dz, IM, LMK, LMP,           &
+                       clouds, cldsa, mtopa, mbota, de_lgth)           !  ---  outputs
 
       endif                                ! end_if_ntcw
 
@@ -1706,7 +1708,7 @@
           if (Model%swhtr) then
             call swrad (plyr, plvl, tlyr, tlvl, qlyr, olyr,     &      !  ---  inputs
                         gasvmr, clouds, Tbd%icsdsw, faersw,     &
-                        sfcalb, dz, delp, de_lgth,              & 
+                        sfcalb, dz, delp, de_lgth,              &
                         Radtend%coszen, Model%solcon,           &
                         nday, idxday, im, lmk, lmp, Model%lprnt,&
                         htswc, Diag%topfsw, Radtend%sfcfsw,     &      !  ---  outputs
@@ -1714,7 +1716,7 @@
           else
             call swrad (plyr, plvl, tlyr, tlvl, qlyr, olyr,     &      !  ---  inputs 
                         gasvmr, clouds, Tbd%icsdsw, faersw,     &
-                        sfcalb, dz, delp, de_lgth,              & 
+                        sfcalb, dz, delp, de_lgth,              &
                         Radtend%coszen, Model%solcon,           &
                         nday, idxday, IM, LMK, LMP, Model%lprnt,&
                         htswc, Diag%topfsw, Radtend%sfcfsw,     &      !  ---  outputs 
@@ -1812,13 +1814,15 @@
         if (Model%lwhtr) then
           call lwrad (plyr, plvl, tlyr, tlvl, qlyr, olyr, gasvmr,  &        !  ---  inputs
                       clouds, Tbd%icsdlw, faerlw, Radtend%semis,   &
-                      tsfg, im, lmk, lmp, Model%lprnt,             &
+                      tsfg, dz, delp, de_lgth,                     &
+                      im, lmk, lmp, Model%lprnt,                   &
                       htlwc, Diag%topflw, Radtend%sfcflw,          &        !  ---  outputs
                       hlw0=htlw0, tau110=tau110)                            !  ---  optional
         else
           call lwrad (plyr, plvl, tlyr, tlvl, qlyr, olyr, gasvmr,  &        !  ---  inputs
                       clouds, Tbd%icsdlw, faerlw, Radtend%semis,   &
-                      tsfg, IM, LMK, LMP, Model%lprnt,             &
+                      tsfg, dz, delp, de_lgth,                     &
+                      IM, LMK, LMP, Model%lprnt,                   &
                       htlwc, Diag%topflw, Radtend%sfcflw,          &
                       tau110=tau110)                                        !  ---  outputs
         endif

--- a/gsmphys/radiation_clouds.F
+++ b/gsmphys/radiation_clouds.F
@@ -20,43 +20,43 @@
 !       'progcld1'           --- zhao/moorthi prognostic cloud scheme  !
 !          inputs:                                                     !
 !           (plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,                   !
-!            xlat,xlon,slmsk,                                          !
+!            xlat,xlon,slmsk,dz                                        !
 !            IX, NLAY, NLP1,                                           !
 !          outputs:                                                    !
-!            clouds,clds,mtop,mbot)                                    !
+!            clouds,clds,mtop,mbot,de_lgth)                            !
 !                                                                      !
 !       'progcld2'           --- ferrier prognostic cloud microphysics !
 !          inputs:                                                     !
 !           (plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,                   !
-!            xlat,xlon,slmsk, f_ice,f_rain,r_rime,flgmin,              !
+!            xlat,xlon,slmsk,dz, f_ice,f_rain,r_rime,flgmin,           !
 !            IX, NLAY, NLP1,                                           !
 !          outputs:                                                    !
-!            clouds,clds,mtop,mbot)                                    !
+!            clouds,clds,mtop,mbot,de_lgth)                            !
 !                                                                      !
 !       'progcld3'           --- zhao/moorthi prognostic cloud + pdfcld!
 !          inputs:                                                     !
 !           (plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw, cnvw,cnvc,        !
-!            xlat,xlon,slmsk,                                          !
+!            xlat,xlon,slmsk,dz                                        !
 !            ix, nlay, nlp1,                                           !
 !            deltaq,sup,kdt,me,                                        !
 !          outputs:                                                    !
-!            clouds,clds,mtop,mbot)
+!            clouds,clds,mtop,mbot,de_lgth)
 !                                                                      !
 !       'progclduni'           --- for unified clouds with MG microphys!
 !          inputs:                                                     !
 !           (plyr,plvl,tlyr,tvly,clw,ciw,                              !
-!            xlat,xlon,slmsk,                                          !
+!            xlat,xlon,slmsk,dz                                        !
 !            IX, NLAY, NLP1,                                           !
 !          outputs:                                                    !
-!            clouds,clds,mtop,mbot)                                    !
+!            clouds,clds,mtop,mbot,de_lgth)                            !
 !                                                                      !
 !       'diagcld1'           --- diagnostic cloud calc routine         !
 !          inputs:                                                     !
 !           (plyr,plvl,tlyr,rhly,vvel,cv,cvt,cvb,                      !
-!            xlat,xlon,slmsk,                                          !
+!            xlat,xlon,slmsk,dz                                        !
 !            IX, NLAY, NLP1,                                           !
 !          outputs:                                                    !
-!            clouds,clds,mtop,mbot)                                    !
+!            clouds,clds,mtop,mbot,de_lgth)                            !
 !                                                                      !
 !    internal accessable only subroutines:                             !
 !       'gethml'             --- get diagnostic hi, mid, low clouds    !
@@ -485,14 +485,15 @@
 !!\param clds       (IX,5), fraction of clouds for low, mid, hi, tot, bl
 !!\param mtop       (IX,3), vertical indices for low, mid, hi cloud tops
 !!\param mbot       (IX,3), vertical indices for low, mid, hi cloud bases
+!!\param de_lgth    (IX),   clouds decorrelation length (km)
 !>\section gen_progcld1 General Algorithm
 !> @{
 !-----------------------------------
       subroutine progcld1                                               &
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,                    &    !  ---  inputs:
-     &       xlat,xlon,slmsk, IX, NLAY, NLP1,                           &
+     &       xlat,xlon,slmsk,dz,IX, NLAY, NLP1,                         &
      &       uni_cld, lmfshal, lmfdeep2, cldcov,                        &
-     &       clouds,clds,mtop,mbot                                      &    !  ---  outputs:
+     &       clouds,clds,mtop,mbot,de_lgth                              &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -531,6 +532,7 @@
 !                     range, otherwise see in-line comment              !
 !   xlon  (IX)      : grid longitude in radians  (not used)             !
 !   slmsk (IX)      : sea/land mask array (sea:0,land:1,sea-ice:2)      !
+!   dz    (ix,nlay) : layer thickness (km)                              !
 !   IX              : horizontal dimention                              !
 !   NLAY,NLP1       : vertical layer/level dimensions                   !
 !   uni_cld         : logical - true for cloud fraction from shoc       !
@@ -553,6 +555,7 @@
 !   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
 !   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
 !   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -577,7 +580,7 @@
       logical, intent(in)  :: uni_cld, lmfshal, lmfdeep2
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,  &
-     &       tlyr, tvly, qlyr, qstl, rhly, clw, cldcov
+     &       tlyr, tvly, qlyr, qstl, rhly, clw, cldcov, dz
 
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk
@@ -586,6 +589,7 @@
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
 
       real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
+      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
 
       integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
@@ -593,7 +597,7 @@
       real (kind=kind_phys), dimension(IX,NLAY) :: cldtot, cldcnv,      &
      &       cwp, cip, crp, csp, rew, rei, res, rer, delp, tem2d, clwf
 
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1)
+      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -655,6 +659,11 @@
 !     ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
 !  ---  i=1,2 are low-lat (<45 degree) and pole regions)
 
+      do i =1, IX
+        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
+!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
+      enddo
+      
       do id = 1, 4
         tem1 = ptopc(id,2) - ptopc(id,1)
 
@@ -882,6 +891,14 @@
         enddo
       enddo
 
+!  --- ...  estimate clouds decorrelation length in km
+!           this is only a tentative test, need to consider change later
+
+      if ( iovr == 3 ) then
+        do i = 1, ix
+          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
+        enddo
+      endif
 
 !> -# Call gethml() to compute low,mid,high,total, and boundary layer
 !!    cloud fractions and clouds top/bottom layer indices for low, mid,
@@ -894,7 +911,7 @@
 
       call gethml                                                       &
 !  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv,                               &
+     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth,                  &
      &       IX,NLAY,                                                   &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
@@ -947,9 +964,9 @@
 !-----------------------------------
       subroutine progcld2                                               &
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,                    &    !  ---  inputs:
-     &       xlat,xlon,slmsk, f_ice,f_rain,r_rime,flgmin,               &
+     &       xlat,xlon,slmsk, dz,f_ice,f_rain,r_rime,flgmin,            &
      &       IX, NLAY, NLP1, lmfshal, lmfdeep2,                         &
-     &       clouds,clds,mtop,mbot                                      &    !  ---  outputs:
+     &       clouds,clds,mtop,mbot,de_lgth                              &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -992,6 +1009,7 @@
 !                     range, otherwise see in-line comment              !
 !   xlon  (IX)      : grid longitude in radians  (not used)             !
 !   slmsk (IX)      : sea/land mask array (sea:0,land:1,sea-ice:2)      !
+!   dz    (ix,nlay) : layer thickness (km)                              !
 !   IX              : horizontal dimention                              !
 !   NLAY,NLP1       : vertical layer/level dimensions                   !
 !                                                                       !
@@ -1010,6 +1028,7 @@
 !   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
 !   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
 !   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! external module variables:                                            !
 !   ivflip          : control flag of vertical index direction          !
@@ -1039,7 +1058,8 @@
       logical, intent(in)  :: lmfshal, lmfdeep2
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,  &
-     &       tlyr, tvly, qlyr, qstl, rhly, clw, f_ice, f_rain, r_rime
+     &      tlyr, tvly, qlyr, qstl, rhly, clw, f_ice, f_rain, r_rime,
+     &      dz
 
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk
@@ -1048,6 +1068,8 @@
 !  ---  outputs
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
 
+      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
+      
       real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
 
       integer,               dimension(:,:),   intent(out) :: mtop,mbot
@@ -1057,7 +1079,7 @@
      &       cwp, cip, crp, csp, rew, rei, res, rer, tem2d, clw2,       &
      &       qcwat, qcice, qrain, fcice, frain, rrime, rsden, clwf
 
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1)
+      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -1114,6 +1136,11 @@
 !    - ptopc(k,i): top pressure of each cld domain (k=1-4 are sfc,l,m,
 !!     h; i=1,2 are low-lat (<45 degree) and pole regions)
 
+      do i =1, IX
+        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
+!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
+      enddo
+      
       do id = 1, 4
         tem1 = ptopc(id,2) - ptopc(id,1)
 
@@ -1384,7 +1411,14 @@
         enddo
       enddo
 
-
+!  --- ...  estimate clouds decorrelation length in km
+!           this is only a tentative test, need to consider change later
+      if ( iovr == 3 ) then
+        do i = 1, ix
+          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
+        enddo
+      endif
+      
 !> -# Call gethml(), to compute low, mid, high, total, and boundary
 !! layer cloud fractions and clouds top/bottom layer indices for low,
 !! mid, and high clouds.
@@ -1394,7 +1428,7 @@
 
       call gethml                                                       &
 !  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv,                               &
+     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth,                  &
      &       IX,NLAY,                                                   &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
@@ -1446,10 +1480,10 @@
 !-----------------------------------
       subroutine progcld3                                               &
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,cnvw,cnvc,          &    !  ---  inputs:
-     &       xlat,xlon,slmsk,                                           &
+     &       xlat,xlon,slmsk,dz,                                        &
      &       ix, nlay, nlp1,                                            &
      &       deltaq,sup,kdt,me,                                         &
-     &       clouds,clds,mtop,mbot                                      &    !  ---  outputs:
+     &       clouds,clds,mtop,mbot,de_lgth                              &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -1488,7 +1522,9 @@
 !                     range, otherwise see in-line comment              !
 !   xlon  (ix)      : grid longitude in radians  (not used)             !
 !   slmsk (ix)      : sea/land mask array (sea:0,land:1,sea-ice:2)      !
+!   dz    (ix,nlay) : layer thickness (km)                              !
 !   ix              : horizontal dimention                              !
+!     
 !   nlay,nlp1       : vertical layer/level dimensions                   !
 !   cnvw  (ix,nlay) : layer convective cloud condensate                 !
 !   cnvc  (ix,nlay) : layer convective cloud cover                      !
@@ -1511,6 +1547,7 @@
 !   clds  (ix,5)    : fraction of clouds for low, mid, hi, tot, bl      !
 !   mtop  (ix,3)    : vertical indices for low, mid, hi cloud tops      !
 !   mbot  (ix,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -1531,7 +1568,7 @@
       integer,  intent(in) :: ix, nlay, nlp1,kdt
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,    &
-     &       tlyr, tvly, qlyr, qstl, rhly, clw
+     &       tlyr, tvly, qlyr, qstl, rhly, clw, dz
 !     &       tlyr, tvly, qlyr, qstl, rhly, clw, cnvw, cnvc
 !      real (kind=kind_phys), dimension(:,:), intent(in) :: deltaq
       real (kind=kind_phys), dimension(:,:) :: deltaq, cnvw, cnvc
@@ -1548,13 +1585,15 @@
 
       real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
 
+      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
+
       integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
 !  ---  local variables:
       real (kind=kind_phys), dimension(ix,nlay) :: cldtot, cldcnv,      &
      &       cwp, cip, crp, csp, rew, rei, res, rer, delp, tem2d, clwf
 
-      real (kind=kind_phys) :: ptop1(ix,nk_clds+1)
+      real (kind=kind_phys) :: ptop1(ix,nk_clds+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -1620,6 +1659,11 @@
 !     ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,l,m,h;
 !  ---  i=1,2 are low-lat (<45 degree) and pole regions)
 
+      do i =1, IX
+        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
+!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
+      enddo
+      
       do id = 1, 4
         tem1 = ptopc(id,2) - ptopc(id,1)
 
@@ -1815,6 +1859,13 @@
         enddo
       enddo
 
+!  --- ...  estimate clouds decorrelation length in km
+!           this is only a tentative test, need to consider change later
+      if ( iovr == 3 ) then
+        do i = 1, ix
+          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
+        enddo
+      endif
 
 !> -# Call gethml() to compute low,mid,high,total, and boundary layer
 !! cloud fractions and clouds top/bottom layer indices for low, mid,
@@ -1826,7 +1877,7 @@
 
       call gethml                                                       &
 !  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv,                               &
+     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth,                  &
      &       ix,nlay,                                                   &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
@@ -1845,7 +1896,7 @@
 
 !  ---  inputs:
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,                    &
-     &       xlat,xlon,slmsk,cldtot, dz                                 &
+     &       xlat,xlon,slmsk,cldtot, dz,                                &
      &       IX, NLAY, NLP1,                                            &
 !  ---  outputs:
      &       clouds,clds,mtop,mbot,de_lgth                              &
@@ -1937,9 +1988,9 @@
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
 
       real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
-      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
-      integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
+      integer,               dimension(:,:),   intent(out) :: mtop,mbot
+      real(kind=kind_phys),  dimension(:),     intent(out) :: de_lgth
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldcnv,              &
      &       cwp, cip, crp, csp, rew, rei, res, rer, delp, tem2d, clwf
@@ -2114,7 +2165,7 @@
           clouds(i,k,9) = rei(i,k)
         enddo
       enddo
-	
+
 !  --- ...  estimate clouds decorrelation length in km
 !           this is only a tentative test, need to consider change later
       if ( iovr == 3 ) then
@@ -2150,10 +2201,10 @@
 
 !  ---  inputs:
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,cnvw,cnvc,          &
-     &       xlat,xlon,slmsk,cldtot,                                    &
+     &       xlat,xlon,slmsk,cldtot,dz,                                 &
      &       IX, NLAY, NLP1,                                            &
 !  ---  outputs:
-     &       clouds,clds,mtop,mbot                                      &
+     &       clouds,clds,mtop,mbot,de_lgth                              &
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -2194,6 +2245,7 @@
 !                     range, otherwise see in-line comment              !
 !   xlon  (IX)      : grid longitude in radians  (not used)             !
 !   slmsk (IX)      : sea/land mask array (sea:0,land:1,sea-ice:2)      !
+!   dz    (ix,nlay) : layer thickness (km)                              !
 !   IX              : horizontal dimention                              !
 !   NLAY,NLP1       : vertical layer/level dimensions                   !
 !                                                                       !
@@ -2212,6 +2264,7 @@
 !   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
 !   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
 !   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -2233,7 +2286,7 @@
       integer,  intent(in) :: IX, NLAY, NLP1
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,  &
-     &       tlyr, tvly, qlyr, qstl, rhly, clw, cnvw, cnvc
+     &       tlyr, tvly, qlyr, qstl, rhly, clw, cnvw, cnvc, dz
 
       real (kind=kind_phys), dimension(:,:), intent(inout) :: cldtot
 
@@ -2245,13 +2298,15 @@
 
       real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
 
+      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
+      
       integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldcnv,              &
      &       cwp, cip, crp, csp, rew, rei, res, rer, delp, tem2d, clwf
 
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1)
+      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -2312,6 +2367,11 @@
 !       ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
 !  ---  i=1,2 are low-lat (<45 degree) and pole regions)
 
+      do i =1, IX
+        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
+!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
+      enddo
+      
       do id = 1, 4
         tem1 = ptopc(id,2) - ptopc(id,1)
 
@@ -2431,7 +2491,14 @@
         enddo
       enddo
 
-
+!  --- ...  estimate clouds decorrelation length in km
+!           this is only a tentative test, need to consider change later
+      if ( iovr == 3 ) then
+        do i = 1, ix
+          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
+        enddo
+      endif
+      
 !  ---  compute low, mid, high, total, and boundary layer cloud fractions
 !       and clouds top/bottom layer indices for low, mid, and high clouds.
 !       The three cloud domain boundaries are defined by ptopc.  The cloud
@@ -2440,7 +2507,7 @@
 
       call gethml                                                       &
 !  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv,                               &
+     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth,                  &
      &       IX,NLAY,                                                   &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
@@ -2459,10 +2526,10 @@
 
 !  ---  inputs:
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,cnvw,cnvc,          &
-     &       xlat,xlon,qw,qr,qi,qs,qg,qa,slmsk,snowd,cldtot,            &
+     &       xlat,xlon,qw,qr,qi,qs,qg,qa,slmsk,snowd,cldtot,dz,         &
      &       IX, NLAY, NLP1,                                            &
 !  ---  outputs:
-     &       clouds,clds,mtop,mbot                                      &
+     &       clouds,clds,mtop,mbot,de_lgth                              &
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -2503,6 +2570,7 @@
 !                     range, otherwise see in-line comment              !
 !   xlon  (IX)      : grid longitude in radians  (not used)             !
 !   slmsk (IX)      : sea/land mask array (sea:0,land:1,sea-ice:2)      !
+!   dz    (ix,nlay) : layer thickness (km)                              !
 !   IX              : horizontal dimention                              !
 !   NLAY,NLP1       : vertical layer/level dimensions                   !
 !                                                                       !
@@ -2521,6 +2589,7 @@
 !   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
 !   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
 !   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -2547,7 +2616,7 @@
       integer,  intent(in) :: IX, NLAY, NLP1
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,  &
-     &       tlyr, tvly, qlyr, qstl, rhly, clw, cnvw, cnvc
+     &       tlyr, tvly, qlyr, qstl, rhly, clw, cnvw, cnvc, dz
 
       real (kind=kind_phys), dimension(:,:), intent(inout) ::           &
      &       qw, qr, qi, qs, qg, qa
@@ -2561,6 +2630,8 @@
 
       real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
 
+      real (kind=kind_phys), dimension(:),   intent(out) :: de_lgth
+
       integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
 !  ---  local variables:
@@ -2568,7 +2639,7 @@
      &       cwp, cip, crp, csp, cgp, rew, rei, res, rer, reg, delp,    &
      &       tem2d, clwf
 
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1)
+      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -2593,7 +2664,7 @@
 #else
 #ifdef GFS_CLOUD_OVERLAP
       call cld_eff_rad (1, IX, 1, NLAY, slmsk, plyr*100,                &
-     &                  abs(plvl(:,1:NLAY)-plvl(:,2:NLAY+1))*100, tlyr, &
+     &                  abs(plvl(:,1:NLAY)-plvl(:,2:NLAY+1))*100, tylr, &
      &                  qlyr, qw, qi, qr, qs, qg, qa, cwp, cip, crp,    &
      &                  csp, cgp, rew, rei, rer, res, reg, cldtot,      &
      &                  cldtot, snowd, cnvw=cnvw)
@@ -2639,7 +2710,14 @@
         enddo
       enddo
 
-
+!  --- ...  estimate clouds decorrelation length in km
+!           this is only a tentative test, need to consider change later
+      if ( iovr == 3 ) then
+        do i = 1, ix
+          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
+        enddo
+      endif
+      
 !  ---  compute low, mid, high, total, and boundary layer cloud fractions
 !       and clouds top/bottom layer indices for low, mid, and high clouds.
 !       The three cloud domain boundaries are defined by ptopc.  The cloud
@@ -2648,7 +2726,7 @@
 
       call gethml                                                       &
 !  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv,                               &
+     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth,                  &
      &       IX,NLAY,                                                   &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
@@ -2697,8 +2775,8 @@
 !-----------------------------------
       subroutine progclduni                                             &
      &     ( plyr,plvl,tlyr,tvly,clw,ciw,                               &    !  ---  inputs:
-     &       xlat,xlon,slmsk, IX, NLAY, NLP1, cldcov,                   &
-     &       clouds,clds,mtop,mbot                                      &    !  ---  outputs:
+     &       xlat,xlon,slmsk,dz,IX, NLAY, NLP1, cldcov,                 &
+     &       clouds,clds,mtop,mbot,de_lgth                              &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -2735,6 +2813,7 @@
 !                     range, otherwise see in-line comment              !
 !   xlon  (IX)      : grid longitude in radians  (not used)             !
 !   slmsk (IX)      : sea/land mask array (sea:0,land:1,sea-ice:2)      !
+!   dz    (ix,nlay) : layer thickness (km)                              !
 !   IX              : horizontal dimention                              !
 !   NLAY,NLP1       : vertical layer/level dimensions                   !
 !                                                                       !
@@ -2753,6 +2832,7 @@
 !   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
 !   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
 !   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -2775,7 +2855,7 @@
       integer,  intent(in) :: IX, NLAY, NLP1
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,  &
-     &       tlyr, tvly, clw, ciw, cldcov
+     &       tlyr, tvly, clw, ciw, cldcov, dz
 
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk
@@ -2783,6 +2863,8 @@
 !  ---  outputs
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
 
+      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
+      
       real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
 
       integer,               dimension(:,:),   intent(out) :: mtop,mbot
@@ -2792,7 +2874,7 @@
      &       cwp, cip, crp, csp, rew, rei, res, rer, delp, tem2d
 !    &       cwp, cip, crp, csp, rew, rei, res, rer, delp, tem2d, clwf
 
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1)
+      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: tem1, tem2, tem3
 
@@ -2849,6 +2931,11 @@
 !     ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
 !  ---  i=1,2 are low-lat (<45 degree) and pole regions)
 
+      do i =1, IX
+        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
+!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
+      enddo
+      
       do id = 1, 4
         tem1 = ptopc(id,2) - ptopc(id,1)
 
@@ -2964,7 +3051,14 @@
           clouds(i,k,9) = rei(i,k)
         enddo
       enddo
-
+	
+!  --- ...  estimate clouds decorrelation length in km
+!           this is only a tentative test, need to consider change later
+      if ( iovr == 3 ) then
+        do i = 1, ix
+          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
+        enddo
+      endif
 
 !> -# Call gethml() to compute low,mid,high,total, and boundary layer
 !!    cloud fractions and clouds top/bottom layer indices for low, mid,
@@ -2977,7 +3071,7 @@
 
       call gethml                                                       &
 !  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv,                               &
+     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth,                  &
      &       IX,NLAY,                                                   &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
@@ -3019,9 +3113,9 @@
 !-----------------------------------
       subroutine diagcld1                                               &
      &     ( plyr,plvl,tlyr,rhly,vvel,cv,cvt,cvb,                       &    !  ---  inputs:
-     &       xlat,xlon,slmsk,                                           &
+     &       xlat,xlon,slmsk,dz,                                        &
      &       IX, NLAY, NLP1,                                            &
-     &       clouds,clds,mtop,mbot                                      &    !  ---  outputs:
+     &       clouds,clds,mtop,mbot,de_lgth                              &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -3059,6 +3153,7 @@
 !   xlon  (IX)      : grid longitude in radians, ok for both 0->2pi or  !
 !                     -pi -> +pi ranges                                 !
 !   slmsk (IX)      : sea/land mask array (sea:0,land:1,sea-ice:2)      !
+!   dz    (ix,nlay) : layer thickness (km)                              !
 !   cv    (IX)      : fraction of convective cloud                      !
 !   cvt, cvb (IX)   : conv cloud top/bottom pressure in mb              !
 !   IX              : horizontal dimention                              !
@@ -3073,6 +3168,7 @@
 !   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
 !   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
 !   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! external module variables:                                            !
 !   ivflip          : control flag of vertical index direction          !
@@ -3087,7 +3183,7 @@
       integer,  intent(in) :: IX, NLAY, NLP1
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,  &
-     &       tlyr, rhly, vvel
+     &       tlyr, rhly, vvel, dz
 
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk, cv, cvt, cvb
@@ -3096,6 +3192,7 @@
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
 
       real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
+      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
 
       integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
@@ -3103,7 +3200,7 @@
       real (kind=kind_phys), dimension(IX,NLAY) :: cldtot, cldcnv,      &
      &       cldtau, taufac, dthdp, tem2d
 
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1)
+      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: cr1, cr2, crk, pval, cval, omeg, value,  &
      &       tem1, tem2
@@ -3226,6 +3323,11 @@
 
 !> -# Find top pressure for each cloud domain.
 
+      do i =1, IX
+        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
+!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
+      enddo
+      
       do j = 1, 4
         tem1 = ptopc(j,2) - ptopc(j,1)
 
@@ -3591,7 +3693,15 @@
           clouds(i,k,4) = cldasy_def
         enddo
       enddo
-
+	
+!  --- ...  estimate clouds decorrelation length in km
+!           this is only a tentative test, need to consider change later
+      if ( iovr == 3 ) then
+        do i = 1, ix
+          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
+        enddo
+      endif
+      
 !> -# Call gethml(), to compute low, mid, high, total, and boundary
 !!    layer cloud fractions and cloud top/bottom layer indices for low,
 !!    mid, and high clouds.
@@ -3601,7 +3711,7 @@
 
       call gethml                                                       &
 !  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv,                               &
+     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth,                  &
      &       IX, NLAY,                                                  &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
@@ -3697,8 +3807,8 @@
       integer, intent(in) :: IX, NLAY
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plyr, ptop1, &
-     &       cldtot, cldcnv, dz
-      real (kind=kind_phys), dimension(:),   intent(in) :: de_lgth
+     &      cldtot, cldcnv, dz
+      real (kind=kind_phys), dimension(:), intent(in) :: de_lgth
 
 !  ---  outputs
       real (kind=kind_phys), dimension(:,:), intent(out) :: clds

--- a/gsmphys/radiation_clouds.F
+++ b/gsmphys/radiation_clouds.F
@@ -469,6 +469,7 @@
 !!               -pi/2 range, otherwise see in-line comment
 !!\param xlon    (IX), grid longitude in radians  (not used)
 !!\param slmsk   (IX), sea/land mask array (sea:0,land:1,sea-ice:2)
+!!\param dz      (IX,NLAY), layer thickness (km)
 !!\param IX           horizontal dimention
 !!\param NLAY,NLP1    vertical layer/level dimensions
 !!\param clouds      (IX,NLAY,NF_CLDS), cloud profiles
@@ -943,6 +944,7 @@
 !!               -pi/2 range, otherwise see in-line comment
 !!\param xlon    (IX), grid longitude in radians  (not used)
 !!\param slmsk   (IX), sea/land mask array (sea:0,land:1,sea-ice:2)
+!!\param dz      (IX,NLAY), layer thickness (km)
 !!\param IX      horizontal dimention
 !!\param NLAY,NLP1    vertical layer/level dimensions
 !!\param clouds      (IX,NLAY,NF_CLDS), cloud profiles
@@ -959,6 +961,7 @@
 !!\param clds  (IX,5), fraction of clouds for low, mid, hi, tot, bl
 !!\param mtop  (IX,3), vertical indices for low, mid, hi cloud tops
 !!\param mbot  (IX,3), vertical indices for low, mid, hi cloud bases
+!!\param de_lgth    (IX),   clouds decorrelation length (km)
 !>\section gen_progcld2 General Algorithm
 !> @{
 !-----------------------------------
@@ -2664,7 +2667,7 @@
 #else
 #ifdef GFS_CLOUD_OVERLAP
       call cld_eff_rad (1, IX, 1, NLAY, slmsk, plyr*100,                &
-     &                  abs(plvl(:,1:NLAY)-plvl(:,2:NLAY+1))*100, tylr, &
+     &                  abs(plvl(:,1:NLAY)-plvl(:,2:NLAY+1))*100, tlyr, &
      &                  qlyr, qw, qi, qr, qs, qg, qa, cwp, cip, crp,    &
      &                  csp, cgp, rew, rei, rer, res, reg, cldtot,      &
      &                  cldtot, snowd, cnvw=cnvw)

--- a/gsmphys/radlw_main.f
+++ b/gsmphys/radlw_main.f
@@ -455,7 +455,7 @@
       subroutine lwrad                                                  &
      &     ( plyr,plvl,tlyr,tlvl,qlyr,olyr,gasvmr,                      &   !  ---  inputs
      &       clouds,icseed,aerosols,sfemis,sfgtmp,                      &
-     &       dzlyr,delpin,de_lgth,                                      &
+     &       dzlyr,delpin,de_lgth,                                      & 
      &       npts, nlay, nlp1, lprnt,                                   &
      &       hlwc,topflx,sfcflx,                                        &    !  ---  outputs
      &       HLW0,HLWB,FLXPRF,tau110                                    &   !! ---  optional
@@ -706,7 +706,8 @@
 !       (:,m,:) m = 1-h2o/co2, 2-h2o/o3, 3-h2o/n2o, 4-h2o/ch4, 5-n2o/co2, 6-o3/co2
       real (kind=kind_phys) :: rfrate(nlay,nrates,2)
 
-      real (kind=kind_phys) :: tem0, tem1, tem2, pwvcm, summol, stemp
+      real (kind=kind_phys) :: tem0, tem1, tem2, pwvcm, summol, stemp,  &
+     &                         delgth
 
       integer, dimension(npts) :: ipseed
       integer, dimension(nlay) :: jp, jt, jt1, indself, indfor, indminor
@@ -723,7 +724,7 @@
       lhlw0  = present ( hlw0 )
       lflxprf= present ( flxprf )
       ltau110= present ( tau110 )
- 
+
 
       if ( ltau110 ) then
         tau110(:,:) = f_zero
@@ -765,7 +766,8 @@
         endif
 
         stemp = sfgtmp(iplon)          ! surface ground temp
-
+        if (iovrlw == 3) delgth= de_lgth(iplon)    ! clouds decorr-length
+        
 !> -# Prepare atmospheric profile for use in rrtm.
 !           the vertical index of internal array is from surface to top
 
@@ -1956,7 +1958,7 @@
             enddo
           enddo
 
-        case( 3 )        ! decorrelation length overlap
+       case( 3 )        ! decorrelation length overlap
 
 !  ---  compute overlapping factors based on layer midpoint distances
 !       and decorrelation depths
@@ -1991,10 +1993,8 @@
 !       if a random number (from an independent set -cdfun2) is smaller then the
 !       scale factor: use the upper layer's number,  otherwise use a new random
 !       number (keep the original assigned one).
-
           do k = nlay-1, 1, -1
             k1 = k + 1
-
             do n = 1, ngptlw
               if ( cdfun2(n,k) <= fac_lcf(k1) ) then
                 cdfunc(n,k) = cdfunc(n,k1)


### PR DESCRIPTION
This PR illustrates the edits needed to fully port the decorrelation length overlap scheme to SHiELD.  Note that since `gethml` in the `radiation_clouds.F` file is called by more than just the `progcld4` subroutine, a fair number of more edits were needed.