### PR TITLE
Edits required to fully port decorrelation length overlap scheme (2)

### DIFF
--- a/GFS_layer/GFS_radiation_driver.F90
+++ b/GFS_layer/GFS_radiation_driver.F90
@@ -1204,7 +1204,7 @@
       real(kind=kind_phys) :: raddt, es, qs, delt, tem0d 
 
       real(kind=kind_phys), dimension(size(Grid%xlon,1)) ::             &
-           tsfa, cvt1, cvb1, tem1d, tsfg, tskn
+           tsfa, cvt1, cvb1, tem1d, tsfg, tskn, de_lgth
 
       real(kind=kind_phys), dimension(size(Grid%xlon,1),5)       :: cldsa
       real(kind=kind_phys), dimension(size(Grid%xlon,1),NSPC1)   :: aerodp
@@ -1213,10 +1213,10 @@
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP) :: &
            htswc, htlwc, gcice, grain, grime, htsw0, htlw0, plyr, tlyr,    &
            qlyr, olyr, rhly, tvly,qstl, vvel, clw, ciw, prslk1, tem2da,    &
-           dz,delp,tem2db, cldcov, deltaq, cnvc, cnvw, qa, tau067, tau110
+           dz, delp, cldcov, deltaq, cnvc, cnvw, qa, tau067, tau110
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+1+LTP) :: plvl, tlvl
-
+      real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+1+LTP) :: plvl, tlvl, tem2db
+      
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP,2:Model%ntrac) :: tracer1
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP,NF_CLDS) :: clouds
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP,NF_VGAS) :: gasvmr
@@ -1401,7 +1401,7 @@
             qlyr(i,k1) = max( tem1d(i), Statein%qgrs(i,k,1) )
             tem1d(i)   = min( QME5, qlyr(i,k1) )
             tvly(i,k1) = Statein%tgrs(i,k) * (1.0 + fvirt*qlyr(i,k1)) ! virtual T (K)
-            delp(i,lyb) = plvl(i,lla) - plvl(i,llb)
+            delp(i,k1) = plvl(i,k1+1) - plvl(i,k1)
           enddo
         enddo
 
@@ -1447,7 +1447,7 @@
             qlyr(i,k) = max( tem1d(i), Statein%qgrs(i,k,1) )
             tem1d(i)  = min( QME5, qlyr(i,k) )
             tvly(i,k) = Statein%tgrs(i,k) * (1.0 + fvirt*qlyr(i,k)) ! virtual T (K)
-            delp(i,lyb) = plvl(i,lla) - plvl(i,llb)
+            delp(i,k) = plvl(i,k) - plvl(i,k+1)
           enddo
         enddo
 
@@ -1474,7 +1474,7 @@
           do k = LMK, 1, -1
             dz(i,k) = tem0d * (tem2db(i,k) - tem2db(i,k+1)) * tvly(i,k)
           enddo
-        enddo  
+        enddo
 
       endif                              ! end_if_ivflip
 
@@ -1585,31 +1585,31 @@
           if (Model%uni_cld .and. Model%ncld >= 2) then
             call progclduni (plyr, plvl, tlyr, tvly, clw, ciw,    &    !  ---  inputs
                              Grid%xlat, Grid%xlon, Sfcprop%slmsk, &
-                             IM, LMK, LMP, cldcov(:,1:LMK),       &
-                             clouds, cldsa, mtopa, mbota)              !  ---  outputs
+                             dz, IM, LMK, LMP, cldcov(:,1:LMK),   &
+                             clouds, cldsa, mtopa, mbota, de_lgth)     !  ---  outputs
           else
             call progcld1 (plyr ,plvl, tlyr, tvly, qlyr, qstl,    &    !  ---  inputs
                            rhly, clw, Grid%xlat,Grid%xlon,        &
-                           Sfcprop%slmsk, IM, LMK, LMP,           &
+                           Sfcprop%slmsk, dz, IM, LMK, LMP,       &
                            Model%uni_cld, Model%lmfshal,          &
                            Model%lmfdeep2, cldcov(:,1:LMK),       &
-                           clouds, cldsa, mtopa, mbota)                !  ---  outputs
+                           clouds, cldsa, mtopa, mbota, de_lgth)       !  ---  outputs
           endif
 
         elseif(icmphys == 3) then      ! zhao/moorthi's prognostic cloud+pdfcld
 
           call progcld3 (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,&    !  ---  inputs
                          clw, cnvw, cnvc, Grid%xlat, Grid%xlon,   &
-                         Sfcprop%slmsk,im, lmk, lmp, deltaq,      &
+                         Sfcprop%slmsk, dz, im, lmk, lmp, deltaq, &
                          Model%sup, Model%kdt, me,                &
-                         clouds, cldsa, mtopa, mbota)                  !  ---  outputs
+                         clouds, cldsa, mtopa, mbota, de_lgth)         !  ---  outputs
 
         elseif (icmphys == 4) then           ! zhao/moorthi's prognostic cloud scheme
 
           call progcld4 (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,&    !  ---  inputs
                          clw, Grid%xlat, Grid%xlon, Sfcprop%slmsk,&
-                         tracer1(:,1:lmk,Model%ntclamt), im, lmk, &
-                         lmp,                                     &
+                         tracer1(:,1:lmk,Model%ntclamt), dz, im,  &
+                         lmk, lmp,                                &
                          clouds, cldsa, mtopa, mbota, de_lgth)         !  ---  outputs
 
         elseif (icmphys == 5) then           ! zhao/moorthi's prognostic cloud scheme + pdf cloud & cnvc and cnvw
@@ -1618,7 +1618,8 @@
           call progcld5 (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,&    !  ---  inputs
                          clw, cnvw, cnvc, Grid%xlat, Grid%xlon,   &
                          Sfcprop%slmsk, tracer1(:,1:lmk,Model%ntclamt),&
-                         im, lmk, lmp, clouds, cldsa, mtopa, mbota)    !  ---  outputs
+                         dz, im, lmk, lmp,                        &
+                         clouds, cldsa, mtopa, mbota, de_lgth)         !  ---  outputs
           else
           if (Model%ntal .gt. 0) then
               qa(:,:) = tracer1(:,1:lmk,Model%ntal)
@@ -1631,10 +1632,12 @@
                          tracer1(:,1:lmk,Model%ntrw), &
                          tracer1(:,1:lmk,Model%ntiw), &
                          tracer1(:,1:lmk,Model%ntsw), &
-                         tracer1(:,1:lmk,Model%ntgl), qa, &
+                         tracer1(:,1:lmk,Model%ntgl), &
                          Sfcprop%slmsk, Sfcprop%snowd, &
-                         tracer1(:,1:lmk,Model%ntclamt),&
-                         im, lmk, lmp, clouds, cldsa, mtopa, mbota)    !  ---  outputs
+                         tracer1(:,1:lmk,Model%ntclamt), qa, &
+                         dz, &
+                         im, lmk, lmp, &
+                         clouds, cldsa, mtopa, mbota, de_lgth)         !  ---  outputs
           endif
 
         endif                            ! end if_icmphys
@@ -1656,8 +1659,8 @@
 
         call diagcld1 (plyr, plvl, tlyr, rhly, vvel, Cldprop%cv,  &    !  ---  inputs
                        cvt1, cvb1, Grid%xlat, Grid%xlon,          &
-                       Sfcprop%slmsk, IM, LMK, LMP,               &
-                       clouds, cldsa, mtopa, mbota)                    !  ---  outputs
+                       Sfcprop%slmsk, dz, IM, LMK, LMP,           &
+                       clouds, cldsa, mtopa, mbota, de_lgth)           !  ---  outputs
 
       endif                                ! end_if_ntcw
 
@@ -1706,7 +1709,7 @@
           if (Model%swhtr) then
             call swrad (plyr, plvl, tlyr, tlvl, qlyr, olyr,     &      !  ---  inputs
                         gasvmr, clouds, Tbd%icsdsw, faersw,     &
-                        sfcalb, dz, delp, de_lgth,              & 
+                        sfcalb, dz, delp, de_lgth,              &
                         Radtend%coszen, Model%solcon,           &
                         nday, idxday, im, lmk, lmp, Model%lprnt,&
                         htswc, Diag%topfsw, Radtend%sfcfsw,     &      !  ---  outputs
@@ -1714,7 +1717,7 @@
           else
             call swrad (plyr, plvl, tlyr, tlvl, qlyr, olyr,     &      !  ---  inputs 
                         gasvmr, clouds, Tbd%icsdsw, faersw,     &
-                        sfcalb, dz, delp, de_lgth,              & 
+                        sfcalb, dz, delp, de_lgth,              &
                         Radtend%coszen, Model%solcon,           &
                         nday, idxday, IM, LMK, LMP, Model%lprnt,&
                         htswc, Diag%topfsw, Radtend%sfcfsw,     &      !  ---  outputs 
@@ -1812,13 +1815,15 @@
         if (Model%lwhtr) then
           call lwrad (plyr, plvl, tlyr, tlvl, qlyr, olyr, gasvmr,  &        !  ---  inputs
                       clouds, Tbd%icsdlw, faerlw, Radtend%semis,   &
-                      tsfg, im, lmk, lmp, Model%lprnt,             &
+                      tsfg, dz, delp, de_lgth,                     &
+                      im, lmk, lmp, Model%lprnt,                   &
                       htlwc, Diag%topflw, Radtend%sfcflw,          &        !  ---  outputs
                       hlw0=htlw0, tau110=tau110)                            !  ---  optional
         else
           call lwrad (plyr, plvl, tlyr, tlvl, qlyr, olyr, gasvmr,  &        !  ---  inputs
                       clouds, Tbd%icsdlw, faerlw, Radtend%semis,   &
-                      tsfg, IM, LMK, LMP, Model%lprnt,             &
+                      tsfg, dz, delp, de_lgth,                     &
+                      IM, LMK, LMP, Model%lprnt,                   &
                       htlwc, Diag%topflw, Radtend%sfcflw,          &
                       tau110=tau110)                                        !  ---  outputs
         endif

--- a/gsmphys/radiation_clouds.F
+++ b/gsmphys/radiation_clouds.F
@@ -20,43 +20,43 @@
 !       'progcld1'           --- zhao/moorthi prognostic cloud scheme  !
 !          inputs:                                                     !
 !           (plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,                   !
-!            xlat,xlon,slmsk,                                          !
+!            xlat,xlon,slmsk,dz,                                       !
 !            IX, NLAY, NLP1,                                           !
 !          outputs:                                                    !
-!            clouds,clds,mtop,mbot)                                    !
+!            clouds,clds,mtop,mbot,de_lgth)                            !
 !                                                                      !
 !       'progcld2'           --- ferrier prognostic cloud microphysics !
 !          inputs:                                                     !
 !           (plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,                   !
-!            xlat,xlon,slmsk, f_ice,f_rain,r_rime,flgmin,              !
+!            xlat,xlon,slmsk, f_ice,f_rain,r_rime,flgmin,dz,           !
 !            IX, NLAY, NLP1,                                           !
 !          outputs:                                                    !
-!            clouds,clds,mtop,mbot)                                    !
+!            clouds,clds,mtop,mbot,de_lgth)                            !
 !                                                                      !
 !       'progcld3'           --- zhao/moorthi prognostic cloud + pdfcld!
 !          inputs:                                                     !
 !           (plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw, cnvw,cnvc,        !
-!            xlat,xlon,slmsk,                                          !
+!            xlat,xlon,slmsk,dz,                                       !
 !            ix, nlay, nlp1,                                           !
 !            deltaq,sup,kdt,me,                                        !
 !          outputs:                                                    !
-!            clouds,clds,mtop,mbot)
+!            clouds,clds,mtop,mbot,de_lgth)
 !                                                                      !
 !       'progclduni'           --- for unified clouds with MG microphys!
 !          inputs:                                                     !
 !           (plyr,plvl,tlyr,tvly,clw,ciw,                              !
-!            xlat,xlon,slmsk,                                          !
+!            xlat,xlon,slmsk,dz,                                       !
 !            IX, NLAY, NLP1,                                           !
 !          outputs:                                                    !
-!            clouds,clds,mtop,mbot)                                    !
+!            clouds,clds,mtop,mbot,de_lgth)                            !
 !                                                                      !
 !       'diagcld1'           --- diagnostic cloud calc routine         !
 !          inputs:                                                     !
 !           (plyr,plvl,tlyr,rhly,vvel,cv,cvt,cvb,                      !
-!            xlat,xlon,slmsk,                                          !
+!            xlat,xlon,slmsk,dz,                                       !
 !            IX, NLAY, NLP1,                                           !
 !          outputs:                                                    !
-!            clouds,clds,mtop,mbot)                                    !
+!            clouds,clds,mtop,mbot,de_lgth)                            !
 !                                                                      !
 !    internal accessable only subroutines:                             !
 !       'gethml'             --- get diagnostic hi, mid, low clouds    !
@@ -469,6 +469,7 @@
 !!               -pi/2 range, otherwise see in-line comment
 !!\param xlon    (IX), grid longitude in radians  (not used)
 !!\param slmsk   (IX), sea/land mask array (sea:0,land:1,sea-ice:2)
+!!\param dz      (IX,NLAY), layer thickness (km)
 !!\param IX           horizontal dimention
 !!\param NLAY,NLP1    vertical layer/level dimensions
 !!\param clouds      (IX,NLAY,NF_CLDS), cloud profiles
@@ -485,14 +486,15 @@
 !!\param clds       (IX,5), fraction of clouds for low, mid, hi, tot, bl
 !!\param mtop       (IX,3), vertical indices for low, mid, hi cloud tops
 !!\param mbot       (IX,3), vertical indices for low, mid, hi cloud bases
+!!\param de_lgth    (IX),   clouds decorrelation length (km)
 !>\section gen_progcld1 General Algorithm
 !> @{
 !-----------------------------------
       subroutine progcld1                                               &
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,                    &    !  ---  inputs:
-     &       xlat,xlon,slmsk, IX, NLAY, NLP1,                           &
+     &       xlat,xlon,slmsk, dz, IX, NLAY, NLP1,                       &
      &       uni_cld, lmfshal, lmfdeep2, cldcov,                        &
-     &       clouds,clds,mtop,mbot                                      &    !  ---  outputs:
+     &       clouds,clds,mtop,mbot,de_lgth                              &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -553,6 +555,7 @@
 !   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
 !   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
 !   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -577,7 +580,7 @@
       logical, intent(in)  :: uni_cld, lmfshal, lmfdeep2
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,  &
-     &       tlyr, tvly, qlyr, qstl, rhly, clw, cldcov
+     &       tlyr, tvly, qlyr, qstl, rhly, clw, cldcov, dz
 
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk
@@ -589,11 +592,13 @@
 
       integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
+      real (kind=kind_phys), dimension(:),   intent(out) :: de_lgth
+
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldtot, cldcnv,      &
      &       cwp, cip, crp, csp, rew, rei, res, rer, delp, tem2d, clwf
 
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1)
+      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -654,6 +659,11 @@
 !> -# Find top pressure for each cloud domain for given latitude.
 !     ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
 !  ---  i=1,2 are low-lat (<45 degree) and pole regions)
+
+      do i =1, IX
+        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
+!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
+      enddo
 
       do id = 1, 4
         tem1 = ptopc(id,2) - ptopc(id,1)
@@ -882,6 +892,13 @@
         enddo
       enddo
 
+!  --- ...  estimate clouds decorrelation length in km
+!           this is only a tentative test, need to consider change later
+      if ( iovr == 3 ) then
+        do i = 1, ix
+          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
+        enddo
+      endif
 
 !> -# Call gethml() to compute low,mid,high,total, and boundary layer
 !!    cloud fractions and clouds top/bottom layer indices for low, mid,
@@ -895,7 +912,7 @@
       call gethml                                                       &
 !  ---  inputs:
      &     ( plyr, ptop1, cldtot, cldcnv,                               &
-     &       IX,NLAY,                                                   &
+     &       IX,NLAY,dz,de_lgth,                                        &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
      &     )
@@ -926,6 +943,7 @@
 !!               -pi/2 range, otherwise see in-line comment
 !!\param xlon    (IX), grid longitude in radians  (not used)
 !!\param slmsk   (IX), sea/land mask array (sea:0,land:1,sea-ice:2)
+!!\param dz      (IX,NLAY), layer thickness (km)
 !!\param IX      horizontal dimention
 !!\param NLAY,NLP1    vertical layer/level dimensions
 !!\param clouds      (IX,NLAY,NF_CLDS), cloud profiles
@@ -942,14 +960,15 @@
 !!\param clds  (IX,5), fraction of clouds for low, mid, hi, tot, bl
 !!\param mtop  (IX,3), vertical indices for low, mid, hi cloud tops
 !!\param mbot  (IX,3), vertical indices for low, mid, hi cloud bases
-!>\section gen_progcld2 General Algorithm
+!!\param de_lgth    (IX),   clouds decorrelation length (km)
+!\>\section gen_progcld2 General Algorithm
 !> @{
 !-----------------------------------
       subroutine progcld2                                               &
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,                    &    !  ---  inputs:
-     &       xlat,xlon,slmsk, f_ice,f_rain,r_rime,flgmin,               &
+     &       xlat,xlon,slmsk, dz, f_ice,f_rain,r_rime,flgmin,           &
      &       IX, NLAY, NLP1, lmfshal, lmfdeep2,                         &
-     &       clouds,clds,mtop,mbot                                      &    !  ---  outputs:
+     &       clouds,clds,mtop,mbot,de_lgth                              &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -992,6 +1011,7 @@
 !                     range, otherwise see in-line comment              !
 !   xlon  (IX)      : grid longitude in radians  (not used)             !
 !   slmsk (IX)      : sea/land mask array (sea:0,land:1,sea-ice:2)      !
+!   dz    (ix,nlay) : layer thickness (km)                              !
 !   IX              : horizontal dimention                              !
 !   NLAY,NLP1       : vertical layer/level dimensions                   !
 !                                                                       !
@@ -1010,6 +1030,7 @@
 !   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
 !   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
 !   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! external module variables:                                            !
 !   ivflip          : control flag of vertical index direction          !
@@ -1039,7 +1060,8 @@
       logical, intent(in)  :: lmfshal, lmfdeep2
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,  &
-     &       tlyr, tvly, qlyr, qstl, rhly, clw, f_ice, f_rain, r_rime
+     &     tlyr, tvly, qlyr, qstl, rhly, clw, f_ice, f_rain, r_rime,    &
+     &     dz
 
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk
@@ -1052,12 +1074,14 @@
 
       integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
+      real (kind=kind_phys), dimension(:), intent(out) :: de_lgth
+
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldtot, cldcnv,      &
      &       cwp, cip, crp, csp, rew, rei, res, rer, tem2d, clw2,       &
      &       qcwat, qcice, qrain, fcice, frain, rrime, rsden, clwf
 
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1)
+      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -1113,6 +1137,11 @@
 !> -# Find top pressure (ptopc) for each cloud domain for given latitude.
 !    - ptopc(k,i): top pressure of each cld domain (k=1-4 are sfc,l,m,
 !!     h; i=1,2 are low-lat (<45 degree) and pole regions)
+
+      do i =1, IX
+        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
+!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
+      enddo
 
       do id = 1, 4
         tem1 = ptopc(id,2) - ptopc(id,1)
@@ -1384,6 +1413,13 @@
         enddo
       enddo
 
+!  --- ...  estimate clouds decorrelation length in km
+!           this is only a tentative test, need to consider change later
+      if ( iovr == 3 ) then
+        do i = 1, ix
+          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
+        enddo
+      endif
 
 !> -# Call gethml(), to compute low, mid, high, total, and boundary
 !! layer cloud fractions and clouds top/bottom layer indices for low,
@@ -1395,7 +1431,7 @@
       call gethml                                                       &
 !  ---  inputs:
      &     ( plyr, ptop1, cldtot, cldcnv,                               &
-     &       IX,NLAY,                                                   &
+     &       IX,NLAY,dz,de_lgth,                                        &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
      &     )
@@ -1422,6 +1458,7 @@
 !!                  -pi/2 range, otherwise see in-line comment
 !!\param xlon       (ix), grid longitude in radians  (not used)
 !!\param slmsk      (ix), sea/land mask array (sea:0,land:1,sea-ice:2)
+!!\param dz         (ix,nlay), layer thickness (km)
 !!\param ix         horizontal dimention
 !!\param nlay,nlp1  vertical layer/level dimensions
 !!\param deltaq     (ix,nlay), half total water distribution width
@@ -1441,15 +1478,16 @@
 !!\param clds      (ix,5), fraction of clouds for low, mid, hi, tot, bl
 !!\param mtop      (ix,3), vertical indices for low, mid, hi cloud tops
 !!\param mbot      (ix,3), vertical indices for low, mid, hi cloud bases
+!!\param de_lgth    (IX),   clouds decorrelation length (km)
 !!\section gen_progcld3 General Algorithm
 !> @{
 !-----------------------------------
       subroutine progcld3                                               &
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,cnvw,cnvc,          &    !  ---  inputs:
-     &       xlat,xlon,slmsk,                                           &
+     &       xlat,xlon,slmsk,dz,                                        &
      &       ix, nlay, nlp1,                                            &
      &       deltaq,sup,kdt,me,                                         &
-     &       clouds,clds,mtop,mbot                                      &    !  ---  outputs:
+     &       clouds,clds,mtop,mbot,de_lgth                              &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -1488,6 +1526,7 @@
 !                     range, otherwise see in-line comment              !
 !   xlon  (ix)      : grid longitude in radians  (not used)             !
 !   slmsk (ix)      : sea/land mask array (sea:0,land:1,sea-ice:2)      !
+!   dz    (ix,nlay) : layer thickness (km)                              !
 !   ix              : horizontal dimention                              !
 !   nlay,nlp1       : vertical layer/level dimensions                   !
 !   cnvw  (ix,nlay) : layer convective cloud condensate                 !
@@ -1511,6 +1550,7 @@
 !   clds  (ix,5)    : fraction of clouds for low, mid, hi, tot, bl      !
 !   mtop  (ix,3)    : vertical indices for low, mid, hi cloud tops      !
 !   mbot  (ix,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -1531,7 +1571,7 @@
       integer,  intent(in) :: ix, nlay, nlp1,kdt
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,    &
-     &       tlyr, tvly, qlyr, qstl, rhly, clw
+     &       tlyr, tvly, qlyr, qstl, rhly, clw, dz
 !     &       tlyr, tvly, qlyr, qstl, rhly, clw, cnvw, cnvc
 !      real (kind=kind_phys), dimension(:,:), intent(in) :: deltaq
       real (kind=kind_phys), dimension(:,:) :: deltaq, cnvw, cnvc
@@ -1550,11 +1590,13 @@
 
       integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
+      real (kind=kind_phys), dimension(:),   intent(out) :: de_lgth
+
 !  ---  local variables:
       real (kind=kind_phys), dimension(ix,nlay) :: cldtot, cldcnv,      &
      &       cwp, cip, crp, csp, rew, rei, res, rer, delp, tem2d, clwf
 
-      real (kind=kind_phys) :: ptop1(ix,nk_clds+1)
+      real (kind=kind_phys) :: ptop1(ix,nk_clds+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -1620,6 +1662,11 @@
 !     ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,l,m,h;
 !  ---  i=1,2 are low-lat (<45 degree) and pole regions)
 
+      do i =1, IX
+        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
+!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
+      enddo
+      
       do id = 1, 4
         tem1 = ptopc(id,2) - ptopc(id,1)
 
@@ -1815,7 +1862,14 @@
         enddo
       enddo
 
-
+!  --- ...  estimate clouds decorrelation length in km
+!           this is only a tentative test, need to consider change later
+      if ( iovr == 3 ) then
+        do i = 1, ix
+          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
+        enddo
+      endif
+      
 !> -# Call gethml() to compute low,mid,high,total, and boundary layer
 !! cloud fractions and clouds top/bottom layer indices for low, mid,
 !! and high clouds.
@@ -1827,7 +1881,7 @@
       call gethml                                                       &
 !  ---  inputs:
      &     ( plyr, ptop1, cldtot, cldcnv,                               &
-     &       ix,nlay,                                                   &
+     &       ix,nlay,dz,de_lgth,                                        &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
      &     )
@@ -1845,7 +1899,7 @@
 
 !  ---  inputs:
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,                    &
-     &       xlat,xlon,slmsk,cldtot, dz                                 &
+     &       xlat,xlon,slmsk,cldtot,dz,                                 &
      &       IX, NLAY, NLP1,                                            &
 !  ---  outputs:
      &       clouds,clds,mtop,mbot,de_lgth                              &
@@ -1937,9 +1991,10 @@
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
 
       real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
-      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
-      integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
+      integer,               dimension(:,:),   intent(out) :: mtop,mbot
+      real(kind=kind_phys),  dimension(:),     intent(out) :: de_lgth
+      
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldcnv,              &
      &       cwp, cip, crp, csp, rew, rei, res, rer, delp, tem2d, clwf
@@ -2114,7 +2169,7 @@
           clouds(i,k,9) = rei(i,k)
         enddo
       enddo
-	
+
 !  --- ...  estimate clouds decorrelation length in km
 !           this is only a tentative test, need to consider change later
       if ( iovr == 3 ) then
@@ -2122,7 +2177,7 @@
           de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
         enddo
       endif
-
+      
 !  ---  compute low, mid, high, total, and boundary layer cloud fractions
 !       and clouds top/bottom layer indices for low, mid, and high clouds.
 !       The three cloud domain boundaries are defined by ptopc.  The cloud
@@ -2131,8 +2186,8 @@
 
       call gethml                                                       &
 !  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth,                  &
-     &       IX,NLAY,                                                   &
+     &     ( plyr, ptop1, cldtot, cldcnv,                               &
+     &       IX,NLAY,dz,de_lgth,                                        &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
      &     )
@@ -2150,10 +2205,10 @@
 
 !  ---  inputs:
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,cnvw,cnvc,          &
-     &       xlat,xlon,slmsk,cldtot,                                    &
+     &       xlat,xlon,slmsk,cldtot,dz,                                 &
      &       IX, NLAY, NLP1,                                            &
 !  ---  outputs:
-     &       clouds,clds,mtop,mbot                                      &
+     &       clouds,clds,mtop,mbot,de_lgth                              &
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -2194,6 +2249,7 @@
 !                     range, otherwise see in-line comment              !
 !   xlon  (IX)      : grid longitude in radians  (not used)             !
 !   slmsk (IX)      : sea/land mask array (sea:0,land:1,sea-ice:2)      !
+!   dz    (ix,nlay) : layer thickness (km)                              !
 !   IX              : horizontal dimention                              !
 !   NLAY,NLP1       : vertical layer/level dimensions                   !
 !                                                                       !
@@ -2212,6 +2268,7 @@
 !   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
 !   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
 !   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -2233,7 +2290,7 @@
       integer,  intent(in) :: IX, NLAY, NLP1
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,  &
-     &       tlyr, tvly, qlyr, qstl, rhly, clw, cnvw, cnvc
+     &       tlyr, tvly, qlyr, qstl, rhly, clw, cnvw, cnvc, dz
 
       real (kind=kind_phys), dimension(:,:), intent(inout) :: cldtot
 
@@ -2247,11 +2304,13 @@
 
       integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
+      real (kind=kind_phys), dimension(:),   intent(out) :: de_lgth
+
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldcnv,              &
      &       cwp, cip, crp, csp, rew, rei, res, rer, delp, tem2d, clwf
 
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1)
+      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -2312,6 +2371,11 @@
 !       ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
 !  ---  i=1,2 are low-lat (<45 degree) and pole regions)
 
+      do i =1, IX
+        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
+!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
+      enddo
+      
       do id = 1, 4
         tem1 = ptopc(id,2) - ptopc(id,1)
 
@@ -2431,6 +2495,13 @@
         enddo
       enddo
 
+!  --- ...  estimate clouds decorrelation length in km
+!           this is only a tentative test, need to consider change later
+      if ( iovr == 3 ) then
+        do i = 1, ix
+          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
+        enddo
+      endif
 
 !  ---  compute low, mid, high, total, and boundary layer cloud fractions
 !       and clouds top/bottom layer indices for low, mid, and high clouds.
@@ -2441,7 +2512,7 @@
       call gethml                                                       &
 !  ---  inputs:
      &     ( plyr, ptop1, cldtot, cldcnv,                               &
-     &       IX,NLAY,                                                   &
+     &       IX,NLAY,dz,de_lgth,                                        &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
      &     )
@@ -2459,10 +2530,10 @@
 
 !  ---  inputs:
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,cnvw,cnvc,          &
-     &       xlat,xlon,qw,qr,qi,qs,qg,qa,slmsk,snowd,cldtot,            &
+     &       xlat,xlon,qw,qr,qi,qs,qg,qa,slmsk,snowd,cldtot,dz,         &
      &       IX, NLAY, NLP1,                                            &
 !  ---  outputs:
-     &       clouds,clds,mtop,mbot                                      &
+     &       clouds,clds,mtop,mbot,de_lgth                              &
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -2503,6 +2574,7 @@
 !                     range, otherwise see in-line comment              !
 !   xlon  (IX)      : grid longitude in radians  (not used)             !
 !   slmsk (IX)      : sea/land mask array (sea:0,land:1,sea-ice:2)      !
+!   dz    (ix,nlay) : layer thickness (km)                              !
 !   IX              : horizontal dimention                              !
 !   NLAY,NLP1       : vertical layer/level dimensions                   !
 !                                                                       !
@@ -2521,6 +2593,7 @@
 !   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
 !   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
 !   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -2547,7 +2620,7 @@
       integer,  intent(in) :: IX, NLAY, NLP1
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,  &
-     &       tlyr, tvly, qlyr, qstl, rhly, clw, cnvw, cnvc
+     &       tlyr, tvly, qlyr, qstl, rhly, clw, cnvw, cnvc, dz
 
       real (kind=kind_phys), dimension(:,:), intent(inout) ::           &
      &       qw, qr, qi, qs, qg, qa
@@ -2563,12 +2636,14 @@
 
       integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
+      real (kind=kind_phys), dimension(:),   intent(out) :: de_lgth
+      
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldcnv,              &
      &       cwp, cip, crp, csp, cgp, rew, rei, res, rer, reg, delp,    &
      &       tem2d, clwf
 
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1)
+      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -2612,6 +2687,11 @@
 !       ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
 !  ---  i=1,2 are low-lat (<45 degree) and pole regions)
 
+      do i =1, IX
+        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
+!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
+      enddo
+      
       do id = 1, 4
         tem1 = ptopc(id,2) - ptopc(id,1)
 
@@ -2639,6 +2719,13 @@
         enddo
       enddo
 
+!  --- ...  estimate clouds decorrelation length in km
+!           this is only a tentative test, need to consider change later
+      if ( iovr == 3 ) then
+        do i = 1, ix
+          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
+        enddo
+      endif
 
 !  ---  compute low, mid, high, total, and boundary layer cloud fractions
 !       and clouds top/bottom layer indices for low, mid, and high clouds.
@@ -2649,7 +2736,7 @@
       call gethml                                                       &
 !  ---  inputs:
      &     ( plyr, ptop1, cldtot, cldcnv,                               &
-     &       IX,NLAY,                                                   &
+     &       IX,NLAY,dz,de_lgth,                                        &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
      &     )
@@ -2676,6 +2763,7 @@
 !!               -pi/2 range, otherwise see in-line comment
 !!\param xlon    (IX), grid longitude in radians  (not used)
 !!\param slmsk   (IX), sea/land mask array (sea:0,land:1,sea-ice:2)
+!!\param dz      (IX,NLAY), layer thickness (km)
 !!\param IX           horizontal dimention
 !!\param NLAY,NLP1    vertical layer/level dimensions
 !!\param clouds      (IX,NLAY,NF_CLDS), cloud profiles
@@ -2692,13 +2780,14 @@
 !!\param clds       (IX,5), fraction of clouds for low, mid, hi, tot, bl
 !!\param mtop       (IX,3), vertical indices for low, mid, hi cloud tops
 !!\param mbot       (IX,3), vertical indices for low, mid, hi cloud bases
+!!\param de_lgth    (IX),   clouds decorrelation length (km)
 !>\section gen_progclduni General Algorithm
 !> @{
 !-----------------------------------
       subroutine progclduni                                             &
      &     ( plyr,plvl,tlyr,tvly,clw,ciw,                               &    !  ---  inputs:
-     &       xlat,xlon,slmsk, IX, NLAY, NLP1, cldcov,                   &
-     &       clouds,clds,mtop,mbot                                      &    !  ---  outputs:
+     &       xlat,xlon,slmsk, dz, IX, NLAY, NLP1, cldcov,               &
+     &       clouds,clds,mtop,mbot,de_lgth                              &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -2735,6 +2824,7 @@
 !                     range, otherwise see in-line comment              !
 !   xlon  (IX)      : grid longitude in radians  (not used)             !
 !   slmsk (IX)      : sea/land mask array (sea:0,land:1,sea-ice:2)      !
+!   dz    (ix,nlay) : layer thickness (km)                              !
 !   IX              : horizontal dimention                              !
 !   NLAY,NLP1       : vertical layer/level dimensions                   !
 !                                                                       !
@@ -2753,6 +2843,7 @@
 !   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
 !   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
 !   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -2775,7 +2866,7 @@
       integer,  intent(in) :: IX, NLAY, NLP1
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,  &
-     &       tlyr, tvly, clw, ciw, cldcov
+     &       tlyr, tvly, clw, ciw, cldcov, dz
 
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk
@@ -2787,12 +2878,14 @@
 
       integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
+      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
+
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldtot, cldcnv,      &
      &       cwp, cip, crp, csp, rew, rei, res, rer, delp, tem2d
 !    &       cwp, cip, crp, csp, rew, rei, res, rer, delp, tem2d, clwf
 
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1)
+      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: tem1, tem2, tem3
 
@@ -2849,6 +2942,11 @@
 !     ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
 !  ---  i=1,2 are low-lat (<45 degree) and pole regions)
 
+      do i =1, IX
+        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
+!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
+      enddo
+      
       do id = 1, 4
         tem1 = ptopc(id,2) - ptopc(id,1)
 
@@ -2965,6 +3063,13 @@
         enddo
       enddo
 
+!  --- ...  estimate clouds decorrelation length in km
+!           this is only a tentative test, need to consider change later
+      if ( iovr == 3 ) then
+        do i = 1, ix
+          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
+        enddo
+      endif
 
 !> -# Call gethml() to compute low,mid,high,total, and boundary layer
 !!    cloud fractions and clouds top/bottom layer indices for low, mid,
@@ -2978,7 +3083,7 @@
       call gethml                                                       &
 !  ---  inputs:
      &     ( plyr, ptop1, cldtot, cldcnv,                               &
-     &       IX,NLAY,                                                   &
+     &       IX,NLAY,dz,de_lgth,                                        &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
      &     )
@@ -3004,6 +3109,7 @@
 !!\param xlon      (IX), grid longitude in radians, ok for both 0->2pi
 !!                 or -pi -> +pi ranges
 !!\param slmsk     (IX), sea/land mask array (sea:0,land:1,sea-ice:2)
+!!\param dz      (IX,NLAY), layer thickness (km)
 !!\param IX        horizontal dimention
 !!\param NLAY,NLP1       vertical layer/level dimensions
 !!\param clouds    (IX,NLAY,NF_CLDS), cloud profiles
@@ -3019,9 +3125,9 @@
 !-----------------------------------
       subroutine diagcld1                                               &
      &     ( plyr,plvl,tlyr,rhly,vvel,cv,cvt,cvb,                       &    !  ---  inputs:
-     &       xlat,xlon,slmsk,                                           &
+     &       xlat,xlon,slmsk,dz,                                        &
      &       IX, NLAY, NLP1,                                            &
-     &       clouds,clds,mtop,mbot                                      &    !  ---  outputs:
+     &       clouds,clds,mtop,mbot,de_lgth                              &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -3061,6 +3167,7 @@
 !   slmsk (IX)      : sea/land mask array (sea:0,land:1,sea-ice:2)      !
 !   cv    (IX)      : fraction of convective cloud                      !
 !   cvt, cvb (IX)   : conv cloud top/bottom pressure in mb              !
+!   dz    (ix,nlay) : layer thickness (km)                              !
 !   IX              : horizontal dimention                              !
 !   NLAY,NLP1       : vertical layer/level dimensions                   !
 !                                                                       !
@@ -3073,6 +3180,7 @@
 !   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
 !   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
 !   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! external module variables:                                            !
 !   ivflip          : control flag of vertical index direction          !
@@ -3087,7 +3195,7 @@
       integer,  intent(in) :: IX, NLAY, NLP1
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,  &
-     &       tlyr, rhly, vvel
+     &       tlyr, rhly, vvel, dz
 
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk, cv, cvt, cvb
@@ -3099,11 +3207,13 @@
 
       integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
+      real (kind=kind_phys), dimension(:),   intent(out) :: de_lgth
+  
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldtot, cldcnv,      &
      &       cldtau, taufac, dthdp, tem2d
 
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1)
+      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: cr1, cr2, crk, pval, cval, omeg, value,  &
      &       tem1, tem2
@@ -3226,6 +3336,11 @@
 
 !> -# Find top pressure for each cloud domain.
 
+      do i =1, IX
+        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
+!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
+      enddo
+      
       do j = 1, 4
         tem1 = ptopc(j,2) - ptopc(j,1)
 
@@ -3592,6 +3707,14 @@
         enddo
       enddo
 
+!  --- ...  estimate clouds decorrelation length in km
+!           this is only a tentative test, need to consider change later
+      if ( iovr == 3 ) then
+        do i = 1, ix
+          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
+        enddo
+      endif
+      
 !> -# Call gethml(), to compute low, mid, high, total, and boundary
 !!    layer cloud fractions and cloud top/bottom layer indices for low,
 !!    mid, and high clouds.
@@ -3602,7 +3725,7 @@
       call gethml                                                       &
 !  ---  inputs:
      &     ( plyr, ptop1, cldtot, cldcnv,                               &
-     &       IX, NLAY,                                                  &
+     &       IX, NLAY, dz, de_lgth,                                     &
 !  ---  outputs:
      &       clds, mtop, mbot                                           &
      &     )
@@ -3625,10 +3748,9 @@
 !!                    (sfc,low,mid,high) in mb (100Pa)
 !> \param cldtot  (IX,NLAY), total or stratiform cloud profile in fraction
 !> \param cldcnv  (IX,NLAY), convective cloud (for diagnostic scheme only)
-!> \param dz      (IX,NLAY), layer thickness (km)
-!> \param de_lgth (IX),  clouds decorrelation length (km)
 !> \param IX      horizontal dimension
 !> \param NLAY    vertical layer dimensions
+!> \param dz     (IX,NLAY), layer thickness (km)
 !> \param clds   (IX,5), fraction of clouds for low, mid, hi, tot, bl 
 !> \param mtop   (IX,3),vertical indices for low, mid, hi cloud tops 
 !> \param mbot   (IX,3),vertical indices for low, mid, hi cloud bases
@@ -3637,8 +3759,8 @@
 !! @{
 !-----------------------------------                                    !
       subroutine gethml                                                 &
-     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth,                  &       !  ---  inputs:
-     &       IX, NLAY,                                                  &
+     &     ( plyr, ptop1, cldtot, cldcnv,                               &       !  ---  inputs:
+     &       IX, NLAY,dz,de_lgth,                                       &
      &       clds, mtop, mbot                                           &       !  ---  outputs:
      &     )
 
@@ -3667,10 +3789,10 @@
 !                     (sfc,low,mid,high) in mb (100Pa)                  !
 !   cldtot(IX,NLAY) : total or straiform cloud profile in fraction      !
 !   cldcnv(IX,NLAY) : convective cloud (for diagnostic scheme only)     !
-!   dz    (ix,nlay) : layer thickness (km)                              !
-!   de_lgth(ix)     : clouds vertical de-correlation length (km)        !
 !   IX              : horizontal dimention                              !
 !   NLAY            : vertical layer dimensions                         !
+!   dz    (ix,nlay) : layer thickness (km)                              !
+!   de_lgth(ix)     : clouds vertical de-correlation length (km)        !      
 !                                                                       !
 ! output variables:                                                     !
 !   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !

--- a/gsmphys/radlw_main.f
+++ b/gsmphys/radlw_main.f
@@ -706,7 +706,8 @@
 !       (:,m,:) m = 1-h2o/co2, 2-h2o/o3, 3-h2o/n2o, 4-h2o/ch4, 5-n2o/co2, 6-o3/co2
       real (kind=kind_phys) :: rfrate(nlay,nrates,2)
 
-      real (kind=kind_phys) :: tem0, tem1, tem2, pwvcm, summol, stemp
+      real (kind=kind_phys) :: tem0, tem1, tem2, pwvcm, summol, stemp,  &
+     &            delgth
 
       integer, dimension(npts) :: ipseed
       integer, dimension(nlay) :: jp, jt, jt1, indself, indfor, indminor
@@ -765,6 +766,7 @@
         endif
 
         stemp = sfgtmp(iplon)          ! surface ground temp
+        if (iovrlw == 3) delgth= de_lgth(iplon)    ! clouds decorr-length
 
 !> -# Prepare atmospheric profile for use in rrtm.
 !           the vertical index of internal array is from surface to top
@@ -1359,13 +1361,13 @@
 !
 !===> ... begin here
 !
-      if ( iovrlw<0 .or. iovrlw>2 ) then
+      if ( iovrlw<0 .or. iovrlw>3 ) then
         print *,'  *** Error in specification of cloud overlap flag',   &
      &          ' IOVRLW=',iovrlw,' in RLWINIT !!'
         stop
-      elseif ( iovrlw==2 .and. isubclw==0 ) then
+      elseif ( iovrlw>=2 .and. isubclw==0 ) then
         if (me == 0) then
-          print *,'  *** IOVRLW=2 - maximum cloud overlap, is not yet', &
+          print *,'  *** IOVRLW=', iovrlw, ', is not yet',              &
      &          ' available for ISUBCLW=0 setting!!'
           print *,'      The program uses maximum/random overlap',      &
      &          ' instead.'
@@ -1538,11 +1540,11 @@
 !    cicep - not used                                              nlay !
 !    reice - not used                                              nlay !
 !                                                                       !
-!    dz     - real, layer thickness (km)                           nlay !
-!    de_lgth- real, layer cloud decorrelation length (km)             1 !
 !    nlay  - integer, number of vertical layers                      1  !
 !    nlp1  - integer, number of vertical levels                      1  !
 !    ipseed- permutation seed for generating random numbers (isubclw>0) !
+!    dz     - real, layer thickness (km)                           nlay !
+!    de_lgth- real, layer cloud decorrelation length (km)             1 !
 !                                                                       !
 !  outputs:                                                             !
 !    cldfmc - real, cloud fraction for each sub-column       ngptlw*nlay!
@@ -1956,7 +1958,7 @@
             enddo
           enddo
 
-        case( 3 )        ! decorrelation length overlap
+       case( 3 )        ! decorrelation length overlap
 
 !  ---  compute overlapping factors based on layer midpoint distances
 !       and decorrelation depths

--- a/gsmphys/radsw_main.f
+++ b/gsmphys/radsw_main.f
@@ -917,6 +917,8 @@
         sntz1  = f_one / cosz(j1)
         ssolar = s0fac * cosz(j1)
 
+        if (iovrsw == 3) delgth = de_lgth(j1) ! clouds decorr-length
+        
 !> -# Prepare surface albedo: bm,df - dir,dif; 1,2 - nir,uvv.
         albbm(1) = sfcalb(j1,1)
         albdf(1) = sfcalb(j1,2)
@@ -1130,7 +1132,7 @@
             endif
           enddo
           zcf0 = zcf0 * zcf1
-        else if (iovrsw >= 2) then
+        else if (iovrsw >= 2) then               ! maximum overlapping
           do k = 1, nlay
             zcf0 = min ( zcf0, f_one-cfrac(k) )  ! used only as clear/cloudy indicator
           enddo
@@ -1461,7 +1463,7 @@
 !
 !===> ... begin here
 !
-      if ( iovrsw<0 .or. iovrsw>2 ) then
+      if ( iovrsw<0 .or. iovrsw>3 ) then
         print *,'  *** Error in specification of cloud overlap flag',   &
      &          ' IOVRSW=',iovrsw,' in RSWINIT !!'
         stop
@@ -1951,7 +1953,7 @@
 !   cldf    - real, layer cloud fraction                           nlay !
 !   nlay    - integer, number of model vertical layers               1  !
 !   ipseed  - integer, permute seed for random num generator         1  !
-!    ** note : if the cloud generator is called multiple times, need    !
+!     ** note : if the cloud generator is called multiple times, need   !
 !              to permute the seed between each call; if between calls  !
 !              for lw and sw, use values differ by the number of g-pts. !
 !    dz    - real, layer thickness (km)                            nlay !
@@ -2084,51 +2086,51 @@
             enddo
           enddo
 
-        case( 3 )        ! decorrelation length overlap
-
-          !  ---  compute overlapping factors based on layer midpoint distances
-          !       and decorrelation depths
+       case( 3 )        ! decorrelation length overlap
+         !  ---  compute overlapping factors based on layer midpoint distances
+         !       and decorrelation depths
           
-                    do k = nlay, 2, -1
-                      fac_lcf(k) = exp( -0.5 * (dz(k)+dz(k-1)) / de_lgth )
-                    enddo
+         do k = nlay, 2, -1
+           fac_lcf(k) = exp( -0.5 * (dz(k)+dz(k-1)) / de_lgth )
+         enddo
           
-          !  ---  setup 2 sets of random numbers
+         !  ---  setup 2 sets of random numbers
           
-                    call random_number ( rand2d, stat )
+         call random_number ( rand2d, stat )
           
-                    k1 = 0
-                    do n = 1, ngptsw
-                      do k = 1, nlay
-                        k1 = k1 + 1
-                        cdfunc(k,n) = rand2d(k1)
-                      enddo
-                    enddo
+         k1 = 0
+         do n = 1, ngptsw
+            do k = 1, nlay
+               k1 = k1 + 1
+               cdfunc(k,n) = rand2d(k1)
+            enddo
+         enddo
+         
+         call random_number ( rand2d, stat )
+         
+         k1 = 0
+         do n = 1, ngptsw
+            do k = 1, nlay
+               k1 = k1 + 1
+               cdfun2(k,n) = rand2d(k1)
+            enddo
+         enddo
           
-                    call random_number ( rand2d, stat )
+         !  ---  then working from the top down:
+         !       if a random number (from an independent set -cdfun2) is smaller
+         !     then the
+         !       scale factor: use the upper layer's number,  otherwise use a new random
+         !       number (keep the original assigned one).
+         
+         do n = 1, ngptsw
+            do k = nlay-1, 1, -1
+               k1 = k + 1
+               if ( cdfun2(k,n) <= fac_lcf(k1) ) then
+                  cdfunc(k,n) = cdfunc(k1,n)
+               endif
+            enddo
+         enddo
           
-                    k1 = 0
-                    do n = 1, ngptsw
-                      do k = 1, nlay
-                        k1 = k1 + 1
-                        cdfun2(k,n) = rand2d(k1)
-                      enddo
-                    enddo
-          
-          !  ---  then working from the top down:
-          !       if a random number (from an independent set -cdfun2) is smaller then the
-          !       scale factor: use the upper layer's number,  otherwise use a new random
-          !       number (keep the original assigned one).
-          
-                    do n = 1, ngptsw
-                      do k = nlay-1, 1, -1
-                        k1 = k + 1
-                        if ( cdfun2(k,n) <= fac_lcf(k1) ) then
-                             cdfunc(k,n) = cdfunc(k1,n)
-                        endif
-                      enddo
-                    enddo
-
       end select
 
 !  --- ...  generate subcolumns for homogeneous clouds


### PR DESCRIPTION
This is a replacement for #1.  Here I confirmed the changes run successfully and that:

- Results with the max-random overlap scheme do not change with these code updates.
- Results with the decorrelation length overlap scheme are identical to the results shared on Slack (i.e. the updates I made in porting the overlap scheme to the other `progcld` subroutines did not change answers, as expected).